### PR TITLE
Process commands that are followed by the bot's username

### DIFF
--- a/lib/crypto_bot.rb
+++ b/lib/crypto_bot.rb
@@ -27,7 +27,7 @@ end
 
 Telegram::Bot::Client.run(authorization_token) do |bot|
   bot.listen do |message|
-    case message.text
+    case CryptoBot::Command.parse(message.text)
     when '/btc'
       CryptoBot::Command::BTC.execute(bot, message)
     when '/eth'

--- a/lib/crypto_bot/command.rb
+++ b/lib/crypto_bot/command.rb
@@ -4,6 +4,16 @@ module CryptoBot
       def execute(*args)
         new(*args).execute
       end
+
+      def parse(message)
+        message.match(pattern)&.[]('command')
+      end
+
+      private
+
+        def pattern
+          /\A(?<command>\/[[:alnum:]\_]+)(@therealcryptobot)?\z/
+        end
     end
 
     def initialize(bot, message)

--- a/lib/crypto_bot/command.rb
+++ b/lib/crypto_bot/command.rb
@@ -1,7 +1,9 @@
 module CryptoBot
   class Command
-    def self.execute(*args)
-      new(*args).execute
+    class << self
+      def execute(*args)
+        new(*args).execute
+      end
     end
 
     def initialize(bot, message)


### PR DESCRIPTION
# Description
If multiple bots are in a group, it is possible to add bot usernames to commands in order to avoid confusion.

```
/start@therealcryptobot
/start@therealdonaldtrump
```

Closes #9 