### PR TITLE
Handle nil messages

### DIFF
--- a/lib/crypto_bot/command.rb
+++ b/lib/crypto_bot/command.rb
@@ -6,7 +6,7 @@ module CryptoBot
       end
 
       def parse(message)
-        message.match(pattern)&.[]('command')
+        message&.match(pattern)&.[]('command')
       end
 
       private


### PR DESCRIPTION
# Description

Some `nil` messages were received by the bot, this raised a `NoMethodError`.

Closes #13